### PR TITLE
fix: ignore underscore throw-away variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ module.exports = {
     // allow '_' as a throw-away variable
     'no-unused-vars': ['error', {
       argsIgnorePattern: '^_$',
+      varsIgnorePattern: '^_$',
     }],
 
     'no-shadow': ['error', {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Underscore variable currently ignored if used as a function argument. I'd like to add an exception to `no-unused-vars` for the cases where underscore used as a variable name:

```js
const [_, desired] = arr;
```

## Motivation and Context

Stumbled upon a case

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
