### PR TITLE
fix: update copyright year

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = {
 
     // enforce license header
     'header/header': [2, 'block', ['',
-      { pattern: ' * Copyright \\d{4} Adobe\\. All rights reserved\\.', template: ' * Copyright 2024 Adobe. All rights reserved.' },
+      { pattern: ' * Copyright \\d{4} Adobe\\. All rights reserved\\.', template: ' * Copyright 2025 Adobe. All rights reserved.' },
       ' * This file is licensed to you under the Apache License, Version 2.0 (the "License");',
       ' * you may not use this file except in compliance with the License. You may obtain a copy',
       ' * of the License at http://www.apache.org/licenses/LICENSE-2.0',


### PR DESCRIPTION
## Description

2024 -> 2025

## Motivation and Context

My automated eslint checker/fixes generates copyright headers with 2024.

## Why is this change required?

The inevitable and perpetual nature of time